### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/app/(marketing)/blog/[slug]/page.jsx
+++ b/app/(marketing)/blog/[slug]/page.jsx
@@ -332,8 +332,24 @@ export default async function ArticlePage({ params }) {
                         className="text-blue-500 hover:text-blue-700 focus:outline-none focus:underline relative hover:opacity-90 transition-all delay-200 duration-500"
                         href={href}
                         {...props}
-                        rel={href?.startsWith('http') && !href?.includes('minifyn.com') ? "noopener noreferrer" : undefined}
-                        target={href?.startsWith('http') && !href?.includes('minifyn.com') ? "_blank" : undefined}
+                        rel={(() => {
+                          try {
+                            const url = new URL(href);
+                            const allowedHosts = ['minifyn.com', 'www.minifyn.com'];
+                            return url.host && !allowedHosts.includes(url.host) ? "noopener noreferrer" : undefined;
+                          } catch {
+                            return undefined;
+                          }
+                        })()}
+                        target={(() => {
+                          try {
+                            const url = new URL(href);
+                            const allowedHosts = ['minifyn.com', 'www.minifyn.com'];
+                            return url.host && !allowedHosts.includes(url.host) ? "_blank" : undefined;
+                          } catch {
+                            return undefined;
+                          }
+                        })()}
                       >
                         {children}
                       </a>


### PR DESCRIPTION
Potential fix for [https://github.com/sylvesterdas/minifyn-homepage/security/code-scanning/3](https://github.com/sylvesterdas/minifyn-homepage/security/code-scanning/3)

To fix the issue, we need to ensure that the `href` value is parsed as a URL and its host is explicitly validated against a whitelist of allowed hosts. This approach prevents bypasses caused by substring matches in unexpected parts of the URL.

**Steps to fix:**
1. Use the `URL` constructor to parse the `href` value and extract its `host`.
2. Define a whitelist of allowed hosts (e.g., `['minifyn.com', 'www.minifyn.com']`).
3. Check if the parsed host is in the whitelist before setting the `rel` and `target` attributes.

**Changes required:**
- Update the logic in the `a` tag rendering function to use host validation instead of substring checks.
- Add a whitelist of allowed hosts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
